### PR TITLE
Add jb alias for jj bookmark

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -191,6 +191,7 @@ alias jst='jj status'
 alias jf='jj git fetch'
 alias jp='jj git push'
 alias jd='jj diff'
+alias jb='jj bookmark'
 jjlt() {
   local n="${1:-10}"
   jj log -r "latest(ancestors(trunk()), $n)" --color=always -T '


### PR DESCRIPTION
## Summary
- Adds `jb` as a shorthand alias for `jj bookmark` in `.zshrc`, matching the existing jj alias pattern.

## Test plan
- [ ] Source `.zshrc` and run `jb` to confirm it invokes `jj bookmark`
- [ ] Verify other jj aliases (`jst`, `jf`, `jp`, `jd`) still work as expected


Made with [Cursor](https://cursor.com)